### PR TITLE
Allow overriding steering configuration keys from CLI

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -400,6 +400,9 @@ class ZprimeAnalysis:
         selections.add("preselection", selections.all("dummy"))
 
         for channel in self.channels:
+            if (req_channels := self.config.general.channels) is not None:
+                if channel not in req_channels:    continue
+
             chname = channel["name"]
             mask = ak.Array(selections.all(chname))
             if process == "data":
@@ -621,9 +624,15 @@ def main():
     )
 
     for dataset, content in fileset.items():
-        os.makedirs(f"{config.general.output_dir}/{dataset}", exist_ok=True)
+
         metadata = content["metadata"]
         metadata["dataset"] = dataset
+        variation = metadata.get("variation", "nominal")
+
+        if (req_processes := config.general.processes) is not None:
+            if dataset.split("__")[0] not in req_processes:    continue
+
+        os.makedirs(f"{config.general.output_dir}/{dataset}", exist_ok=True)
 
         logger.info("========================================")
         logger.info(f"🚀 Processing dataset: {dataset}")

--- a/analysis.py
+++ b/analysis.py
@@ -11,6 +11,7 @@ import glob
 import gzip
 import logging
 import os
+import sys
 import warnings
 
 
@@ -21,6 +22,7 @@ from coffea.nanoevents import NanoAODSchema, NanoEventsFactory
 from correctionlib import CorrectionSet
 import hist
 import numpy as np
+from omegaconf import OmegaConf
 import uproot
 
 from utils.configuration import config as ZprimeConfig
@@ -28,7 +30,7 @@ from utils.cuts import lumi_mask
 from utils.input_files import construct_fileset
 from utils.output_files import save_histograms
 from utils.preproc import pre_process_dak, pre_process_uproot
-from utils.schema import Config
+from utils.schema import Config, load_config_with_restricted_cli
 from utils.stats import get_cabinetry_rebinning_router
 
 # -----------------------------
@@ -606,7 +608,13 @@ def main():
     Main driver function for running the Zprime analysis framework.
     Loads configuration, runs preprocessing, and dispatches analysis over datasets.
     """
-    config = Config(**ZprimeConfig)
+
+    cli_args = sys.argv[1:]
+    full_config = load_config_with_restricted_cli(ZprimeConfig, cli_args)
+    config = Config(**full_config)  # Pydantic validation
+    # ✅ You now have a fully validated config object
+    print(f"Luminosity: {config.general.lumi}")
+
     analysis = ZprimeAnalysis(config)
     fileset = construct_fileset(
         n_files_max_per_sample=config.general.max_files

--- a/utils/schema.py
+++ b/utils/schema.py
@@ -1,6 +1,8 @@
+import copy
 import re
 from typing import Annotated, Callable, List, Literal, Optional, Tuple, Union
 
+from omegaconf import OmegaConf
 from pydantic import BaseModel, Field, model_validator
 
 
@@ -391,3 +393,54 @@ class Config(SubscriptableModel):
                 )
 
         return self
+
+
+def load_config_with_restricted_cli(base_cfg: dict, cli_args: list[str]) -> dict:
+    """
+    Load base config and override only `general`, `preprocess`, or `statistics`
+    keys via CLI arguments in dotlist form.
+
+    Parameters
+    ----------
+    base_cfg : dict
+        The full Python config with logic, lambdas, etc.
+    cli_args : list of str
+        CLI args in OmegaConf dotlist format (e.g. general.lumi=25000)
+
+    Returns
+    -------
+    dict
+        Full merged config (with overrides applied to whitelisted sections only).
+    """
+    ALLOWED_CLI_TOPLEVEL_KEYS = {"general", "preprocess", "statistics"}
+
+    # Deep copy so we don’t modify the original
+    base_copy = copy.deepcopy(base_cfg)
+
+    # Filter CLI args to allowed keys only
+    filtered_cli = []
+    for arg in cli_args:
+        top_key = arg.split("=", 1)[0].split(".", 1)[0]
+        if top_key in ALLOWED_CLI_TOPLEVEL_KEYS:
+            filtered_cli.append(arg)
+        else:
+            raise ValueError(
+                f"Override of top-level key `{top_key}` is not allowed. "
+                f"Allowed keys: {', '.join(ALLOWED_CLI_TOPLEVEL_KEYS)}"
+            )
+
+    # Merge CLI with OmegaConf
+    cli_cfg = OmegaConf.from_dotlist(filtered_cli)
+    safe_base = OmegaConf.create({
+        k: v for k, v in base_copy.items()
+        if k in ALLOWED_CLI_TOPLEVEL_KEYS
+    })
+    merged_cfg = OmegaConf.merge(safe_base, cli_cfg)
+    updated_subsections = OmegaConf.to_container(merged_cfg, resolve=True)
+
+    # Patch back into full config
+    for k in ALLOWED_CLI_TOPLEVEL_KEYS:
+        if k in updated_subsections:
+            base_copy[k] = updated_subsections[k]
+
+    return base_copy

--- a/utils/schema.py
+++ b/utils/schema.py
@@ -68,6 +68,20 @@ class GeneralConfig(SubscriptableModel):
             default=None, description="Directory containing preprocessed files"
         ),
     ]
+    processes: Annotated[
+        Optional[List[str]],
+        Field(
+            default=None,
+            description="List of processes to include in the analysis",
+        ),
+    ]
+    channels: Annotated[
+        Optional[List[str]],
+        Field(
+            default=None,
+            description="List of channels to include in the analysis",
+        ),
+    ]
 
 # ------------------------
 # Preprocessing configuration


### PR DESCRIPTION
Example use (Mac, `zsh`):
```
python analysis.py general.run_histogramming=True general.processes=\["signal"\] general.run_statistics=False
```